### PR TITLE
Add link to iOS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ Flags:
       --bar-top            Bar is on top
   -h, --help               help for gif-progress
 ```
+
+## iOS Version
+<img src="https://raw.githubusercontent.com/aheze/ProgressGif/main/Assets/GitHub/Logo/LogoWithShadow.png" width="200">
+
+A similar, [open-source](https://github.com/aheze/ProgressGif) app called ProgressGif is [available on the App Store](https://apps.apple.com/us/app/id1526969349)! Contributions are welcome.


### PR DESCRIPTION
Hey! I recently built an open-source iOS app, 99% written in Swift, that does pretty much what this repo does. You can check it out on the [App Store](https://apps.apple.com/us/app/id1526969349)!

It's called ProgressGif, and here's the [GitHub repo](https://github.com/aheze/ProgressGif). So far, it has all the features of gif-progress except for bar placement (top or bottom). I've also added some more:

- Edge inset
- Corner radius
- Shadow (beta)

I added a link to it inside your README, if you're ok with that! Otherwise just ignore this pull request.